### PR TITLE
Added command for wheels voltage open-loop control

### DIFF
--- a/Edubot_EncodersAndMotors/Edubot_EncodersAndMotors.ino
+++ b/Edubot_EncodersAndMotors/Edubot_EncodersAndMotors.ino
@@ -127,6 +127,16 @@ void decodeCommand(String message){
             digitalWrite(LEFT_BRIDGE_A, LOW);
             digitalWrite(LEFT_BRIDGE_B, LOW);
             break;
+
+        case 'w':
+            int iSep = message.indexOf(';', 1);
+            if (iSep > 1)
+            {
+                double left  = message.substring(1, iSep).toDouble();
+                double right = message.substring(iSep + 1).toDouble();
+                edu_wheel(left, right);
+            }
+            break;
         
         default:;
     }

--- a/lib/eduLib/Edubot.h
+++ b/lib/eduLib/Edubot.h
@@ -258,6 +258,24 @@ void edu_rotate(double degs)
 	 edu_stop();delay(300);
 }
 
+void edu_wheel(double left, double right)
+{
+	if (left > 1.0)
+		left = 1.0;
+	else if (left < -1.0)
+		left = -1.0;
+
+	if (right > 1.0)
+		right = 1.0;
+	else if (right < -1.0)
+		right = -1.0;
+
+	wheelLeft.setVoltage(maxMvolt*left);
+	wheelRight.setVoltage(maxMvolt*right);
+	
+	control_on = false;
+}
+
 
 void setup_timer2()
 {


### PR DESCRIPTION
Command syntax: "w[left];[right]", where [left] and [right] are double between -1.0 and 1.0.
Examples:
- "w1.0;1.0" - both wheels at full speed
- "w0.5;1.0" - left wheel at half speed, right wheel at full speed
- "w-0.5;0" - left wheel at reverse half speed, right wheel stopped